### PR TITLE
Combined docker compose file for starting front- & backend simultaneously

### DIFF
--- a/Apps/docker-compose.yml
+++ b/Apps/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  backend:
+    image: sosci/backend
+    build: 
+      context: ./backend
+      dockerfile: ./Dockerfile
+    
+    container_name: "combined-app_sosci-backend"
+    restart: always
+
+    ports:
+      - 9000:34254
+
+  frontend:
+    image: sosci/frontend
+    build: 
+      context: ./frontend
+      dockerfile: ./Dockerfile
+    
+    container_name: "combined-app_sosci-frontend"
+    restart: always
+
+    ports:
+      - 5000:80

--- a/Apps/frontend/docker-compose.yml
+++ b/Apps/frontend/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  backend:
+  frontend:
     image: sosci/frontend
     build: 
       context: ./


### PR DESCRIPTION
Created a third docker-compose file for starting front- & backend with one single command.
It uses a different namespace (combined-app prefix) to avoid issues with containers from single builds.