### PR TITLE
Feature/45 time sweep

### DIFF
--- a/Apps/frontend/cypress/e2e/2-control-panel/on-off-button.js
+++ b/Apps/frontend/cypress/e2e/2-control-panel/on-off-button.js
@@ -1,0 +1,19 @@
+/// <reference types="cypress" />
+
+describe('everything visible on front page', () => {
+    beforeEach(() => {
+      cy.visit('http://localhost:5173/')
+    })
+  
+    it('displays btn', () => {
+      cy.get('.control-panel').should('be.visible')
+      cy.get('.btn-on-off').should('be.visible')
+    })
+  
+    it('click btn', () => {
+      // We use the `cy.get()` to get the canvas element
+      cy.get('#btn-on-off').click()
+    })
+  
+  })
+  

--- a/Apps/frontend/src/App.svelte
+++ b/Apps/frontend/src/App.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from "svelte";
   import Logo from "./views/Logo.svelte";
-  import OnOffButton from "./views/OnOffButton.svelte";
   import Oscilloscope from "./views/Oscilloscope.svelte";
 </script>
 
@@ -12,7 +11,6 @@
   <div class="canvas">
     <Oscilloscope />
   </div>
-  <OnOffButton on:switch-plot-enabled={async (event)  => {console.log('Turned ' + (event.detail.enabled ? 'on' : 'off') +'...')}} />
 </main>
 
 <style>

--- a/Apps/frontend/src/const.js
+++ b/Apps/frontend/src/const.js
@@ -6,4 +6,5 @@ export const NUM_INTERVALS_X = 20;
 export const NUM_INTERVALS_Y = 10;
 
 export const NUM_CHANNELS = 10;
-export const MAX_SWEEP = 2;
+export const MIN_SWEEP  = 0.5;// <= 1
+export const MAX_SWEEP  = 2.0;// >= 1

--- a/Apps/frontend/src/const.js
+++ b/Apps/frontend/src/const.js
@@ -4,3 +4,6 @@ export const CANVAS_WIDTH = 1000;
 export const CANVAS_HEIGHT = 500;
 export const NUM_INTERVALS_X = 20;
 export const NUM_INTERVALS_Y = 10;
+
+export const NUM_CHANNELS = 10;
+export const MAX_SWEEP = 2;

--- a/Apps/frontend/src/stores.js
+++ b/Apps/frontend/src/stores.js
@@ -2,3 +2,5 @@ import { writable } from 'svelte/store';
 
 
 export const osciData = writable([]);
+
+export const timeSweep = writable(new Array(10).fill(5));

--- a/Apps/frontend/src/stores.js
+++ b/Apps/frontend/src/stores.js
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
+import { NUM_CHANNELS } from './const';
 
 
 export const osciData = writable([]);
 
-export const timeSweep = writable(new Array(10).fill(5));
+export const timeSweep = writable(new Array(NUM_CHANNELS).fill(5));

--- a/Apps/frontend/src/views/OnOffButton.svelte
+++ b/Apps/frontend/src/views/OnOffButton.svelte
@@ -14,4 +14,12 @@
 </script>
 
 <br>
-<button on:click={handleClick}>{label}</button>
+<button id="btn-on-off" on:click={handleClick}>{label}</button>
+
+
+<style>
+    #btn-on-off {
+        border-style: solid;
+        border-color: grey;
+    }
+</style>

--- a/Apps/frontend/src/views/Oscilloscope.svelte
+++ b/Apps/frontend/src/views/Oscilloscope.svelte
@@ -41,7 +41,9 @@
 </div>
 
 <div class="wrapper" id="control-panel">
-  <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
+  <div id="btn-on-off">
+    <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
+  </div>
 </div>
 
 <style>

--- a/Apps/frontend/src/views/Oscilloscope.svelte
+++ b/Apps/frontend/src/views/Oscilloscope.svelte
@@ -2,11 +2,14 @@
   import { onMount, onDestroy } from "svelte";
   import CoordinateSystem from "./CoordinateSystem.svelte";
   import SineWave from "./SineWave.svelte";
+  import OnOffButton from "./OnOffButton.svelte";
   import { CANVAS_WIDTH } from "../const";
 
   let waveElement;
   let scaleY = 1; // 1V per horizontal line
   let socket;
+
+  let isEnabled = false;
 
   onMount(() => {
     socket = new WebSocket("ws://localhost:9000");
@@ -18,7 +21,7 @@
 
     socket.onmessage = (message) => {
       let samples = new Float64Array(message.data);
-
+      if (!isEnabled) { return; }
       waveElement.updateBuffer(samples);
     };
   });
@@ -31,6 +34,7 @@
 <div class="wrapper" data-cy="oscilloscope">
   <div class="stack coordinate-system">
     <CoordinateSystem yScale={scaleY} />
+    <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
   </div>
   <div class="stack wave">
     <SineWave bind:this={waveElement} {scaleY} />

--- a/Apps/frontend/src/views/Oscilloscope.svelte
+++ b/Apps/frontend/src/views/Oscilloscope.svelte
@@ -3,7 +3,8 @@
   import CoordinateSystem from "./CoordinateSystem.svelte";
   import SineWave from "./SineWave.svelte";
   import OnOffButton from "./OnOffButton.svelte";
-  import { CANVAS_WIDTH } from "../const";
+  import TimeSweepSlider from "./TimeSweepSlider.svelte";
+  import { NUM_CHANNELS } from "../const";
 
   let waveElement;
   let scaleY = 1; // 1V per horizontal line
@@ -44,6 +45,11 @@
   <div id="btn-on-off">
     <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
   </div>
+  <div id="slider-container">
+    {#each Array(NUM_CHANNELS) as _, i}
+      <div class="slider"><TimeSweepSlider channel={i} /></div>
+    {/each}
+  </div>
 </div>
 
 <style>
@@ -62,5 +68,11 @@
   }
   #control-panel {
     top: 500px;
+  }
+  #slider-container {
+    display: table;
+  }
+  .slider {
+    display: table-cell;
   }
 </style>

--- a/Apps/frontend/src/views/Oscilloscope.svelte
+++ b/Apps/frontend/src/views/Oscilloscope.svelte
@@ -21,7 +21,7 @@
 
     socket.onmessage = (message) => {
       let samples = new Float64Array(message.data);
-      if (!isEnabled) { return; }
+      if (!isEnabled) return;
       waveElement.updateBuffer(samples);
     };
   });
@@ -34,11 +34,14 @@
 <div class="wrapper" data-cy="oscilloscope">
   <div class="stack coordinate-system">
     <CoordinateSystem yScale={scaleY} />
-    <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
   </div>
   <div class="stack wave">
     <SineWave bind:this={waveElement} {scaleY} />
   </div>
+</div>
+
+<div class="wrapper" id="control-panel">
+  <OnOffButton on:switch-plot-enabled={(e) => {isEnabled = e.detail.enabled;}} />
 </div>
 
 <style>
@@ -54,5 +57,8 @@
   }
   .wave {
     z-index: 1;
+  }
+  #control-panel {
+    top: 500px;
   }
 </style>

--- a/Apps/frontend/src/views/SineWave.svelte
+++ b/Apps/frontend/src/views/SineWave.svelte
@@ -1,15 +1,14 @@
 <script>
   import { beforeUpdate, onMount } from "svelte";
   import { ColorRGBA, WebglLine, WebglPlot } from "webgl-plot";
-  import { CANVAS_HEIGHT, CANVAS_WIDTH, NUM_INTERVALS_Y, MAX_SWEEP, NUM_CHANNELS } from "../const";
+  import { CANVAS_HEIGHT, CANVAS_WIDTH, NUM_INTERVALS_Y, NUM_CHANNELS, MIN_SWEEP, MAX_SWEEP } from "../const";
   import { timeSweep } from "../stores";
 
   export let scaleY;
 
   let canvasElement;
   let webGLPlot;
-  let numberOfChannels = 10;
-  let channel_samples = Array.from(Array(numberOfChannels), () => new Array(CANVAS_WIDTH).fill(0.0))
+  let channel_samples = Array.from(Array(NUM_CHANNELS), () => new Array(CANVAS_WIDTH).fill(0.0))
   let lines = []
 
   let xArr = new Array(NUM_CHANNELS).fill(0.0);
@@ -20,13 +19,16 @@
       let xCurr = xArr[channelIndex];
       let xNew = Math.round(xCurr);
       for (let x = xLast[channelIndex] + 1; x < xNew + 1; x++) {
-        channel_samples[channelIndex][x] = samples[channelIndex]
+        channel_samples[channelIndex][x] = samples[channelIndex];
       }
       xLast[channelIndex] = xNew;
 
-      let sweep = $timeSweep[channelIndex] / 5.0;
-      xArr[channelIndex] = xCurr + sweep;
-      while (xArr[channelIndex] >= CANVAS_WIDTH) {xArr[channelIndex] -= CANVAS_WIDTH;}
+      let sweep = $timeSweep[channelIndex] / 5.0 - 1.0;
+      let fac = sweep < 0 ? MIN_SWEEP : MAX_SWEEP;
+      let delta = fac * sweep + 1.0;
+
+      xArr[channelIndex] = xCurr + delta;
+      while (xArr[channelIndex] >= CANVAS_WIDTH) { xArr[channelIndex] -= CANVAS_WIDTH; }
     }
   }
 
@@ -53,7 +55,7 @@
   }
   
   const initializeLines = () => {
-    for (let i = 0; i < numberOfChannels; i++)
+    for (let i = 0; i < NUM_CHANNELS; i++)
     {
       const color = new ColorRGBA(Math.random(), Math.random(), Math.random(), 1);
       let line = new WebglLine(color, CANVAS_WIDTH);

--- a/Apps/frontend/src/views/SineWave.svelte
+++ b/Apps/frontend/src/views/SineWave.svelte
@@ -1,7 +1,8 @@
 <script>
   import { beforeUpdate, onMount } from "svelte";
   import { ColorRGBA, WebglLine, WebglPlot } from "webgl-plot";
-  import { CANVAS_HEIGHT, CANVAS_WIDTH, NUM_INTERVALS_Y } from "../const";
+  import { CANVAS_HEIGHT, CANVAS_WIDTH, NUM_INTERVALS_Y, MAX_SWEEP, NUM_CHANNELS } from "../const";
+  import { timeSweep } from "../stores";
 
   export let scaleY;
 
@@ -11,14 +12,22 @@
   let channel_samples = Array.from(Array(numberOfChannels), () => new Array(CANVAS_WIDTH).fill(0.0))
   let lines = []
 
-  let x = 0
+  let xArr = new Array(NUM_CHANNELS).fill(0.0);
+  let xLast = new Array(NUM_CHANNELS).fill(0);
   export const updateBuffer = (samples) => {
     for (let channelIndex = 0; channelIndex < channel_samples.length; channelIndex++)
     {
-      channel_samples[channelIndex][x] = samples[channelIndex]
+      let xCurr = xArr[channelIndex];
+      let xNew = Math.round(xCurr);
+      for (let x = xLast[channelIndex] + 1; x < xNew + 1; x++) {
+        channel_samples[channelIndex][x] = samples[channelIndex]
+      }
+      xLast[channelIndex] = xNew;
+
+      let sweep = $timeSweep[channelIndex] / 5.0;
+      xArr[channelIndex] = xCurr + sweep;
+      while (xArr[channelIndex] >= CANVAS_WIDTH) {xArr[channelIndex] -= CANVAS_WIDTH;}
     }
-    x++;
-    x = x % CANVAS_WIDTH;
   }
 
   const update = () => {

--- a/Apps/frontend/src/views/TimeSweepSlider.svelte
+++ b/Apps/frontend/src/views/TimeSweepSlider.svelte
@@ -1,0 +1,8 @@
+<script>
+    import { timeSweep } from "../stores";
+    export let channel;
+</script>
+
+<div>
+    <input type="range" min="0" max="10" class="slider" bind:value={$timeSweep[channel]}>
+</div>


### PR DESCRIPTION
I know that here tests are missing but I am not sure how to test the webgl plot with cypress yet and I would like to have this reviewed before testing as the reviewers might propose changes anyways which would require to adapt the tests.

Furthermore, I did not take care of the design and positioning of the sliders at all because we will need to design and implement something like a contiguous control panel (which includes labels, slider and on-off-button for each channel) in the next sprints anyways.

Regarding the functionality: the sliders range from 0 to 10. In SineWave#updateBuffer the x-value for each channel is calculated individually and based on that sweep value. For this, the value from the sliders are rescaled from (0,10) to (-1,+1). Those scaled values serve as factor for the amount of sweep of MIN_SWEEP, MAX_SWEEP respectively. Hence, slider values 5 (mid) corresponds to factor 0, so no sweep.
I am not sure if these calculations make sense.