### PR TITLE
Implemented feature #62-cursor

### DIFF
--- a/Apps/frontend/src/components/Waves.svelte
+++ b/Apps/frontend/src/components/Waves.svelte
@@ -77,7 +77,9 @@
       channelSamplesInjectCursor[channelIndex] = channelSamples[channelIndex];
       // inject cursor (undefined values are not rendered) before the newest data sample
       for (let x = xNew + 1; x < xNew + WAVE_CURSOR_SIZE; x++) {
-        channelSamplesInjectCursor[channelIndex][x] = undefined;
+        channelSamplesInjectCursor[channelIndex][
+          x % channelSamplesInjectCursor[channelIndex].length
+        ] = undefined;
       }
 
       xLast[channelIndex] = xNew;

--- a/Apps/frontend/src/const.js
+++ b/Apps/frontend/src/const.js
@@ -34,3 +34,4 @@ export const MIN_SWEEP = 0.5; // <= 1
 export const MAX_SWEEP = 2.0; // >= 1
 export const MIN_AMPLITUDE = 0.0;
 export const MAX_AMPLITUDE = NUM_INTERVALS_HORIZONTAL / 2;
+export const WAVE_CURSOR_SIZE = 50;


### PR DESCRIPTION
Implemented the cursor by injecting undefined data (not being displayed) in front of the new sample data.


<img width="1004" alt="image" src="https://user-images.githubusercontent.com/29018131/205452869-3e74474d-84e8-4310-ae54-aee2843f63ef.png">

Signed-off-by: Marcel Schöckel <marcel.schoeckel@gmail.com>