### PR TITLE
Fix automated deployment and web environments

### DIFF
--- a/Apps/frontend/.env.production
+++ b/Apps/frontend/.env.production
@@ -1,1 +1,1 @@
-VITE_BACKEND_WEBSOCKET=wss://amos-sosci.die-degens.eu/prod/api
+VITE_BACKEND_WEBSOCKET=wss://amos-sosci.die-degens.eu/api

--- a/Apps/frontend/vite.config.js
+++ b/Apps/frontend/vite.config.js
@@ -4,4 +4,5 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  base: './'
 });

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -32,14 +32,15 @@ services:
       - "traefik.http.routers.sosci-dev-frontend-web.service=sosci-dev-frontend-websecure"
       - "traefik.http.middlewares.sosci-dev-frontend-websecure.redirectscheme.scheme=https"
       - "traefik.http.routers.sosci-dev-frontend-web.middlewares=sosci-dev-frontend-websecure"
-      - "traefik.http.routers.sosci-dev-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)  && PathPrefix(`/dev/ui`)"
+      - "traefik.http.routers.sosci-dev-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)  && PathPrefix(`/dev/ui/`)"
       - "traefik.http.routers.sosci-dev-frontend-web.entrypoints=web"
         # HTTPS
-      - "traefik.http.routers.sosci-dev-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/dev/ui`)"
+      - "traefik.http.routers.sosci-dev-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/dev/ui/`)"
       - "traefik.http.routers.sosci-dev-frontend-websecure.entrypoints=websecure"
       - "traefik.http.routers.sosci-dev-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-dev-frontend-websecure.service=sosci-dev-frontend-websecure"
       - "traefik.http.services.sosci-dev-frontend-websecure.loadbalancer.server.port=80"
+      - "traefik.http.routers.sosci-dev-frontend-websecure.middlewares=sosci-frontend-stripprefix-dev"
 
   backend:
     image: sosci/backend:${VERSION_TAG:-nightly}

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       - "traefik.http.routers.sosci-dev-frontend-web.service=sosci-dev-frontend-websecure"
       - "traefik.http.middlewares.sosci-dev-frontend-websecure.redirectscheme.scheme=https"
       - "traefik.http.routers.sosci-dev-frontend-web.middlewares=sosci-dev-frontend-websecure"
-      - "traefik.http.routers.sosci-dev-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)  && PathPrefix(`/dev/ui/`)"
+      - "traefik.http.routers.sosci-dev-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)  && PathPrefix(`/dev/ui`)"
       - "traefik.http.routers.sosci-dev-frontend-web.entrypoints=web"
         # HTTPS
-      - "traefik.http.routers.sosci-dev-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/dev/ui/`)"
+      - "traefik.http.routers.sosci-dev-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/dev/ui`)"
       - "traefik.http.routers.sosci-dev-frontend-websecure.entrypoints=websecure"
       - "traefik.http.routers.sosci-dev-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-dev-frontend-websecure.service=sosci-dev-frontend-websecure"

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         # Redirect HTTP
       - "traefik.http.routers.sosci-dev-frontend-web.service=sosci-dev-frontend-websecure"
       - "traefik.http.middlewares.sosci-dev-frontend-websecure.redirectscheme.scheme=https"
-      - "traefik.http.routers.sosci-dev-frontend-web.middlewares=sosci-dev-frontend-websecure,sosci-frontend-stripprefix-dev"
+      - "traefik.http.routers.sosci-dev-frontend-web.middlewares=sosci-dev-frontend-websecure"
       - "traefik.http.routers.sosci-dev-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)  && PathPrefix(`/dev/ui`)"
       - "traefik.http.routers.sosci-dev-frontend-web.entrypoints=web"
         # HTTPS

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - backend
     restart: unless-stopped
     networks:
-      - internal
       - web
     labels:
       - "traefik.enable=true"

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     restart: unless-stopped
     networks:
       - web
+      - internal
     labels:
       - "traefik.enable=true"
       # Remove path prefix

--- a/Deployments/web_deployment/dev/docker-compose.yml
+++ b/Deployments/web_deployment/dev/docker-compose.yml
@@ -40,7 +40,6 @@ services:
       - "traefik.http.routers.sosci-dev-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-dev-frontend-websecure.service=sosci-dev-frontend-websecure"
       - "traefik.http.services.sosci-dev-frontend-websecure.loadbalancer.server.port=80"
-      - "traefik.http.routers.sosci-dev-frontend-websecure.middlewares=sosci-frontend-stripprefix-dev"
 
   backend:
     image: sosci/backend:${VERSION_TAG:-nightly}

--- a/Deployments/web_deployment/int/docker-compose.yml
+++ b/Deployments/web_deployment/int/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - backend
     restart: unless-stopped
     networks:
-      - internal
       - web
     labels:
       - "traefik.enable=true"

--- a/Deployments/web_deployment/int/docker-compose.yml
+++ b/Deployments/web_deployment/int/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         # Redirect HTTP
       - "traefik.http.routers.sosci-int-frontend-web.service=sosci-int-frontend-websecure"
       - "traefik.http.middlewares.sosci-int-frontend-websecure.redirectscheme.scheme=https"
-      - "traefik.http.routers.sosci-int-frontend-web.middlewares=sosci-int-frontend-websecure,sosci-frontend-stripprefix-int"
+      - "traefik.http.routers.sosci-int-frontend-web.middlewares=sosci-int-frontend-websecure"
       - "traefik.http.routers.sosci-int-frontend-web.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/int/ui`)"
       - "traefik.http.routers.sosci-int-frontend-web.entrypoints=web"
         # HTTPS

--- a/Deployments/web_deployment/prod/docker-compose.yml
+++ b/Deployments/web_deployment/prod/docker-compose.yml
@@ -31,10 +31,10 @@ services:
       - "traefik.http.routers.sosci-prod-frontend-web.service=sosci-prod-frontend-websecure"
       - "traefik.http.middlewares.sosci-prod-frontend-websecure.redirectscheme.scheme=https"
       - "traefik.http.routers.sosci-prod-frontend-web.middlewares=sosci-prod-frontend-websecure"
-      - "traefik.http.routers.sosci-prod-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)"
+      - "traefik.http.routers.sosci-prod-frontend-web.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/ui`)"
       - "traefik.http.routers.sosci-prod-frontend-web.entrypoints=web"
         # HTTPS
-      - "traefik.http.routers.sosci-prod-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`)"
+      - "traefik.http.routers.sosci-prod-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/ui`)"
       - "traefik.http.routers.sosci-prod-frontend-websecure.entrypoints=websecure"
       - "traefik.http.routers.sosci-prod-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-prod-frontend-websecure.service=sosci-prod-frontend-websecure"

--- a/Deployments/web_deployment/prod/docker-compose.yml
+++ b/Deployments/web_deployment/prod/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - backend
     restart: unless-stopped
     networks:
-      - internal
       - web
     labels:
       - "traefik.enable=true"
@@ -54,9 +53,9 @@ services:
     labels:
       - "traefik.enable=true"
       # Remove path prefix
-      - "traefik.http.middlewares.sosci-backend-stripprefix-prod.stripprefix.prefixes=/prod/api"
+      - "traefik.http.middlewares.sosci-backend-stripprefix-prod.stripprefix.prefixes=/api"
         # Main
-      - "traefik.http.routers.sosci-prod-backend.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/prod/api`)"
+      - "traefik.http.routers.sosci-prod-backend.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/api`)"
       - "traefik.http.routers.sosci-prod-backend.entrypoints=websecure"
       - "traefik.http.routers.sosci-prod-backend.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-prod-backend.service=sosci-prod-backend"

--- a/Deployments/web_deployment/prod/docker-compose.yml
+++ b/Deployments/web_deployment/prod/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - web
     labels:
       - "traefik.enable=true"
+      # Remove path prefix
+      - "traefik.http.middlewares.sosci-frontend-stripprefix-prod.stripprefix.prefixes=/ui"
         # Redirect HTTP
       - "traefik.http.routers.sosci-prod-frontend-web.service=sosci-prod-frontend-websecure"
       - "traefik.http.middlewares.sosci-prod-frontend-websecure.redirectscheme.scheme=https"
@@ -37,6 +39,7 @@ services:
       - "traefik.http.routers.sosci-prod-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-prod-frontend-websecure.service=sosci-prod-frontend-websecure"
       - "traefik.http.services.sosci-prod-frontend-websecure.loadbalancer.server.port=80"
+      - "traefik.http.routers.sosci-prod-frontend-websecure.middlewares=sosci-frontend-stripprefix-prod"
 
   backend:
     image: sosci/backend:${VERSION_TAG:-latest}

--- a/Deployments/web_deployment/prod/docker-compose.yml
+++ b/Deployments/web_deployment/prod/docker-compose.yml
@@ -26,21 +26,18 @@ services:
       - web
     labels:
       - "traefik.enable=true"
-      # Remove path prefix
-      - "traefik.http.middlewares.sosci-frontend-stripprefix-prod.stripprefix.prefixes=/prod/ui"
         # Redirect HTTP
       - "traefik.http.routers.sosci-prod-frontend-web.service=sosci-prod-frontend-websecure"
       - "traefik.http.middlewares.sosci-prod-frontend-websecure.redirectscheme.scheme=https"
-      - "traefik.http.routers.sosci-prod-frontend-web.middlewares=sosci-prod-frontend-websecure,sosci-frontend-stripprefix-prod"
-      - "traefik.http.routers.sosci-prod-frontend-web.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/prod/ui`)"
+      - "traefik.http.routers.sosci-prod-frontend-web.middlewares=sosci-prod-frontend-websecure"
+      - "traefik.http.routers.sosci-prod-frontend-web.rule=Host(`amos-sosci.die-degens.eu`)"
       - "traefik.http.routers.sosci-prod-frontend-web.entrypoints=web"
         # HTTPS
-      - "traefik.http.routers.sosci-prod-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`) && PathPrefix(`/prod/ui`)"
+      - "traefik.http.routers.sosci-prod-frontend-websecure.rule=Host(`amos-sosci.die-degens.eu`)"
       - "traefik.http.routers.sosci-prod-frontend-websecure.entrypoints=websecure"
       - "traefik.http.routers.sosci-prod-frontend-websecure.tls.certresolver=letsencrypt"
       - "traefik.http.routers.sosci-prod-frontend-websecure.service=sosci-prod-frontend-websecure"
       - "traefik.http.services.sosci-prod-frontend-websecure.loadbalancer.server.port=80"
-      - "traefik.http.routers.sosci-prod-frontend-websecure.middlewares=sosci-frontend-stripprefix-prod"
 
   backend:
     image: sosci/backend:${VERSION_TAG:-latest}


### PR DESCRIPTION
- Reconfigured web config to don't strip prefixes during http redirect
- Production environment is now served from https://amos-sosci.die-degens.eu/ui/