### PR TITLE
feature/#166 Indicators: Remove bouncing balls

### DIFF
--- a/Apps/frontend/src/app.scss
+++ b/Apps/frontend/src/app.scss
@@ -106,6 +106,11 @@ nav {
   grid-column: 1/3;
   grid-row: 2;
   justify-self: end;
+  font-family: monospace;
+  font-size: 12px;
+  text-align: right;
+  line-height: normal;
+  padding-right: 10px;
 }
 
 .oscilloscope {

--- a/Apps/frontend/src/app.scss
+++ b/Apps/frontend/src/app.scss
@@ -107,10 +107,10 @@ nav {
   grid-row: 2;
   justify-self: end;
   font-family: monospace;
-  font-size: 12px;
+  font-size: min(1em, 2vw);
   text-align: right;
-  line-height: normal;
-  padding-right: 10px;
+  line-height: calc(0.5vw + 0.5em);
+  padding-right: 1vmax;
 }
 
 .oscilloscope {

--- a/Apps/frontend/src/helper.js
+++ b/Apps/frontend/src/helper.js
@@ -9,9 +9,12 @@ import { INDICATOR_DECIMAL_PLACES } from "./const";
 export const rgbArrayToRGBAString = (rgb) =>
   `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 1)`;
 
-export const roundVoltage = (voltage) =>
-  Math.trunc(voltage * 10 ** INDICATOR_DECIMAL_PLACES) /
-  10 ** INDICATOR_DECIMAL_PLACES;
+export const roundVoltage = (voltage) => {
+  return (
+    Math.trunc(voltage * 10 ** INDICATOR_DECIMAL_PLACES) /
+    10 ** INDICATOR_DECIMAL_PLACES
+  );
+};
 
 export const logSocketCloseCode = (code) => {
   // See https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1

--- a/Apps/frontend/src/views/GeneralButtons.svelte
+++ b/Apps/frontend/src/views/GeneralButtons.svelte
@@ -22,7 +22,7 @@
       onOffButton.click();
     }
     // clear canvas and indicators
-    indicatorElement.clearCanvas();
+    indicatorElement.reset();
     waveElement.resetPlot();
   }}
 />

--- a/Apps/frontend/src/views/Indicators.svelte
+++ b/Apps/frontend/src/views/Indicators.svelte
@@ -23,6 +23,11 @@
     }
   };
 
+  export const reset = () => {
+    min = Array(NUM_CHANNELS).fill(0.0);
+    max = Array(NUM_CHANNELS).fill(0.0);
+  }
+
   /**
    * Start or stop indicator updates of a channel.
    *

--- a/Apps/frontend/src/views/Indicators.svelte
+++ b/Apps/frontend/src/views/Indicators.svelte
@@ -1,88 +1,26 @@
+<link rel="stylesheet" href="../app.scss">
 <script>
-  import { onMount } from "svelte";
   import {
-    CANVAS_HEIGHT,
-    INDICATOR_FONT_SIZE,
-    INDICATOR_MARGIN,
-    INDICATOR_SECTION_WIDTH,
-    INDICATOR_WIDTH,
-    INDICATOR_ZERO_LINE_COLOR,
-    LINE_COLORS_RGBA,
     NUM_CHANNELS,
-    NUM_INTERVALS_HORIZONTAL,
   } from "../const";
   import { roundVoltage } from "../helper";
+  import { LINE_COLORS_RGBA } from "../const.js";
 
-  let canvasElement;
-  let canvasContext;
-  let current = Array(NUM_CHANNELS).fill(0.0);
   let min = Array(NUM_CHANNELS).fill(0.0);
   let max = Array(NUM_CHANNELS).fill(0.0);
-  let offsets = Array(NUM_CHANNELS).fill(0.0);
-  let scalings = Array(NUM_CHANNELS).fill(1.0);
   let startStopLine = Array(NUM_CHANNELS).fill(true);
-
-  export let scaleY;
 
   /**
    * Trigger a rerender of the indicators with given sample array.
    *
    * @param {number[]} samples
    */
-  export const update = (samples, startIndex) => {
-    clearCanvas();
-    drawGlobalZeroLine();
-
+  export const update = (samples) => {
     for (let channel = 0; channel < NUM_CHANNELS; channel++) {
-      if (startStopLine[channel]) {
-        updateCurrentMinMax(samples[startIndex + channel], channel);
-      }
-      const transformedMin = transformSampleToYCoord(
-        min[channel],
-        offsets[channel],
-        scalings[channel]
-      );
-      const transformedMax = transformSampleToYCoord(
-        max[channel],
-        offsets[channel],
-        scalings[channel]
-      );
-      const transformedZero = transformSampleToYCoord(
-        0,
-        offsets[channel],
-        scalings[channel]
-      );
-      drawMinMaxZeroLines(
-        channel,
-        transformedMin,
-        transformedMax,
-        transformedZero,
-        LINE_COLORS_RGBA[channel]
-      );
-      writeText(channel, min[channel], max[channel]);
+      if (!startStopLine[channel]) continue;
+      if (samples[channel] > max[channel]) max[channel] = samples[channel];
+      if (samples[channel] < min[channel]) min[channel] = samples[channel];
     }
-  };
-
-  /**
-   * Update the offset of a channel by a voltage.
-   *
-   * @param {number} channelIndex
-   * @param {number} offsetY
-   */
-  export const updateChannelOffsetY = (channelIndex, offsetY) => {
-    offsets[channelIndex] = offsetY;
-    update(current);
-  };
-
-  /**
-   * Update the scaling/amplification of a channel by a factor.
-   *
-   * @param {number} channelIndex
-   * @param {number} scaling
-   */
-  export const updateChannelScaling = (channelIndex, scaling) => {
-    scalings[channelIndex] = scaling;
-    update(current);
   };
 
   /**
@@ -94,131 +32,13 @@
   export const startStopChannelI = (channelIndex, hasStarted) => {
     startStopLine[channelIndex] = hasStarted;
   };
-
-  // ----- Svelte lifecycle hooks -----
-  onMount(() => {
-    resizeCanvas();
-    update(current);
-  });
-
-  // ----- Business logic -----
-
-  /**
-   * Update the current, minimum and maximum voltage of a channel.
-   *
-   * @param {number} sample
-   * @param {number} i
-   */
-  const updateCurrentMinMax = (sample, i) => {
-    current[i] = sample;
-    if (sample < min[i]) {
-      min[i] = sample;
-    }
-    if (sample > max[i]) {
-      max[i] = sample;
-    }
-  };
-
-  /**
-   * Transform a given raw sample to a y coordinate with respect to offset and scaling.
-   * @param {number} sample
-   * @param {number} offset
-   * @param {number} scale
-   * @returns {number} y coordinate
-   */
-  const transformSampleToYCoord = (sample, offset, scale) => {
-    const transformedOffset = offset * (CANVAS_HEIGHT / 2);
-    const transformedScale = scale * (CANVAS_HEIGHT / NUM_INTERVALS_HORIZONTAL);
-    return -sample * transformedScale * scaleY - transformedOffset;
-  };
-
-  /**
-   * Clear the whole canvas.
-   */
-  export const clearCanvas = () => {
-    canvasContext.clearRect(
-      -canvasElement.width,
-      -(canvasElement.height / 2),
-      canvasElement.width,
-      canvasElement.height
-    );
-  };
-
-  /**
-   * Resize the canvas.
-   */
-  const resizeCanvas = () => {
-    canvasElement.height = CANVAS_HEIGHT;
-    canvasContext = canvasElement.getContext("2d");
-    // Translate coordinates to have zero point at the right center
-    canvasContext.translate(canvasElement.width, canvasElement.height / 2);
-  };
-
-  /**
-   * Draw a zero line at the vertical center of the canvas.
-   */
-  const drawGlobalZeroLine = () => {
-    canvasContext.beginPath();
-    canvasContext.strokeStyle = INDICATOR_ZERO_LINE_COLOR;
-    canvasContext.moveTo(0, 0);
-    canvasContext.lineTo(-INDICATOR_SECTION_WIDTH, 0);
-    canvasContext.stroke();
-    canvasContext.font = `${INDICATOR_FONT_SIZE}px Arial`;
-    canvasContext.fillStyle = INDICATOR_ZERO_LINE_COLOR;
-    canvasContext.textAlign = "left";
-    canvasContext.fillText("0", -INDICATOR_SECTION_WIDTH, INDICATOR_FONT_SIZE);
-  };
-
-  /**
-   * Draw the zero, minimum and maximum lines of a channel.
-   *
-   * @param {number} channel
-   * @param {number} min
-   * @param {number} max
-   * @param {number} zero
-   * @param {string} color
-   */
-  const drawMinMaxZeroLines = (channel, min, max, zero, color) => {
-    const x = -(INDICATOR_WIDTH + INDICATOR_MARGIN) * (channel + 1);
-    canvasContext.beginPath();
-    canvasContext.fillStyle = color;
-    canvasContext.strokeStyle = color;
-    // minimum
-    canvasContext.moveTo(x - 4, min);
-    canvasContext.lineTo(x + 4, min);
-    canvasContext.stroke();
-    // maximum
-    canvasContext.moveTo(x - 4, max);
-    canvasContext.lineTo(x + 4, max);
-    canvasContext.stroke();
-    //zero
-    canvasContext.moveTo(x - 6, zero);
-    canvasContext.lineTo(x + 6, zero);
-    canvasContext.stroke();
-  };
-
-  /**
-   * Write the textual representation of the minimum and maximum values of a channel.
-   *
-   * @param {number} channel
-   * @param {number} min
-   * @param {number} max
-   */
-  const writeText = (channel, min, max) => {
-    const roundedMin = roundVoltage(min);
-    const roundedMax = roundVoltage(max);
-    canvasContext.font = `${INDICATOR_FONT_SIZE}px monospace`;
-    canvasContext.fillText(
-      `[${channel}] Min:${roundedMin} V`,
-      -INDICATOR_SECTION_WIDTH,
-      -(CANVAS_HEIGHT / 2) + (channel + 1) * 2 * INDICATOR_FONT_SIZE
-    );
-    canvasContext.fillText(
-      `    Max:${roundedMax} V`,
-      -INDICATOR_SECTION_WIDTH,
-      -(CANVAS_HEIGHT / 2) + (channel + 1.5) * 2 * INDICATOR_FONT_SIZE
-    );
-  };
 </script>
 
-<canvas data-cy="indicators" bind:this={canvasElement} />
+{#each min as _, i}
+    <div style="color: {LINE_COLORS_RGBA[i]}">
+      [{i}]
+      Min: {roundVoltage(min[i])} V
+      <br>
+      Max: {roundVoltage(max[i])} V
+    </div>
+{/each}

--- a/Apps/frontend/src/views/Indicators.svelte
+++ b/Apps/frontend/src/views/Indicators.svelte
@@ -34,6 +34,7 @@
   };
 </script>
 
+<div data-cy="indicators">
 {#each min as _, i}
     <div style="color: {LINE_COLORS_RGBA[i]}">
       [{i}]
@@ -42,3 +43,4 @@
       Max: {roundVoltage(max[i])} V
     </div>
 {/each}
+</div>

--- a/Apps/frontend/src/views/Oscilloscope.svelte
+++ b/Apps/frontend/src/views/Oscilloscope.svelte
@@ -82,7 +82,7 @@
       <GeneralButtons {waveElement} {indicatorElement} />
     </div>
     <div class="indicators">
-      <Indicators bind:this={indicatorElement} scaleY={Math.max(...scalesY)} />
+      <Indicators bind:this={indicatorElement} />
     </div>
     <div class="oscilloscope">
       <div class="oscilloscope--coordinate-system">


### PR DESCRIPTION
As discussed, I removed the bouncing balls from the indicators.
As there are no graphics needed anymore and no heavy computation of positions, I also removed the canvas and display the min max values as plain text.

I know there is no issue regarding this, but I didn't have much time this week for contributing.
So I just created this branch to have this topic from the table as soon as possible to move on.

Signed-off-by: Leander Tolksdorf <leander.tolksdorf@fu-berlin.de>