### PR TITLE
Remove unused webgl-plot

### DIFF
--- a/Apps/frontend/package-lock.json
+++ b/Apps/frontend/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.2.1",
-        "sveltestrap": "^5.10.0",
-        "webgl-plot": "^0.7.0"
+        "sveltestrap": "^5.10.0"
       },
       "devDependencies": {
         "@cypress/code-coverage": "^3.10.0",
@@ -6015,9 +6014,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -8247,11 +8246,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/webgl-plot": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/webgl-plot/-/webgl-plot-0.7.0.tgz",
-      "integrity": "sha512-/prs3XMFKlXcov3qvx3LxqMws0Dg68kmmHmO82Qm6FFGpeKME7c3nuVqSe9CG47BvG9mGVPxDMjRc0DP/jTc2A=="
     },
     "node_modules/webpack": {
       "version": "5.75.0",
@@ -12918,9 +12912,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -14514,11 +14508,6 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
-    },
-    "webgl-plot": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/webgl-plot/-/webgl-plot-0.7.0.tgz",
-      "integrity": "sha512-/prs3XMFKlXcov3qvx3LxqMws0Dg68kmmHmO82Qm6FFGpeKME7c3nuVqSe9CG47BvG9mGVPxDMjRc0DP/jTc2A=="
     },
     "webpack": {
       "version": "5.75.0",

--- a/Apps/frontend/package.json
+++ b/Apps/frontend/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "axios": "^1.2.1",
-    "sveltestrap": "^5.10.0",
-    "webgl-plot": "^0.7.0"
+    "sveltestrap": "^5.10.0"
   }
 }


### PR DESCRIPTION
Signed-off-by: Philipp Kramer <philipp.p.kramer@gmail.com>

Now correctly branched 🙃
Since we migrated to pure webgl we should remove the unused webgl-plot library.